### PR TITLE
Makes protype mood oneOf

### DIFF
--- a/lib/components/KawaiiIceCream/KawaiiIceCream.js
+++ b/lib/components/KawaiiIceCream/KawaiiIceCream.js
@@ -100,7 +100,7 @@ KawaiiIceCream.propTypes = {
     /**
     * One of: 'sad', 'shocked', 'happy', 'blissful', 'lovestruck'
     */
-    mood: _react2.default.PropTypes.string,
+    mood: _react2.default.PropTypes.oneOf(['sad', 'shocked', 'happy', 'blissful', 'lovestruck']),
     /**
     * Hex color
     */

--- a/lib/components/KawaiiPlanet/KawaiiPlanet.js
+++ b/lib/components/KawaiiPlanet/KawaiiPlanet.js
@@ -111,7 +111,7 @@ KawaiiPlanet.propTypes = {
   /**
     * One of: 'sad', 'shocked', 'happy', 'blissful', 'lovestruck'
     */
-  mood: _react2.default.PropTypes.string,
+  mood: _react2.default.PropTypes.oneOf(['sad', 'shocked', 'happy', 'blissful', 'lovestruck']),
   /**
     * Hex color
     */

--- a/src/components/KawaiiIceCream/KawaiiIceCream.jsx
+++ b/src/components/KawaiiIceCream/KawaiiIceCream.jsx
@@ -72,10 +72,7 @@ KawaiiIceCream.propTypes = {
   * Size of the width
   */
   size: React.PropTypes.number,
-  /**
-  * One of: 'sad', 'shocked', 'happy', 'blissful', 'lovestruck'
-  */
-  mood: React.PropTypes.string,
+  mood: React.PropTypes.oneOf(['sad', 'shocked', 'happy', 'blissful', 'lovestruck']),
   /**
   * Hex color
   */

--- a/src/components/KawaiiPlanet/KawaiiPlanet.jsx
+++ b/src/components/KawaiiPlanet/KawaiiPlanet.jsx
@@ -79,10 +79,7 @@ KawaiiPlanet.propTypes = {
     * Size of the width
     */
   size: React.PropTypes.number,
-  /**
-    * One of: 'sad', 'shocked', 'happy', 'blissful', 'lovestruck'
-    */
-  mood: React.PropTypes.string,
+  mood: React.PropTypes.oneOf(['sad', 'shocked', 'happy', 'blissful', 'lovestruck']),
   /**
     * Hex color
     */


### PR DESCRIPTION
Uses Reacts `oneOf` to the mood protype in both components.
https://facebook.github.io/react/docs/typechecking-with-proptypes.html
Thought it would be nice to have it explicitly in the Proptypes.

Let me know what you think :)

