### PR TITLE
Remove styled-component dependency from components 

### DIFF
--- a/src/components/common/wrapper/Wrapper.js
+++ b/src/components/common/wrapper/Wrapper.js
@@ -1,7 +1,10 @@
-import styled from 'styled-components';
+import React from 'react';
 
-const Wrapper = styled.div`
-  position: relative;
-`;
+function Wrapper(props) {
+  return React.createElement('div', {
+    ...props,
+    style: { position: 'relative', ...(props.style || {}) }
+  });
+}
 
 export default Wrapper;

--- a/src/components/planet/Planet.jsx
+++ b/src/components/planet/Planet.jsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import paths from './paths';
 import Face from '../common/face/Face';


### PR DESCRIPTION
Currently `styled-components` is only used in one place in the exported components, and only for one line of style. Removing this reduces `lib/index.js` from 88kb to 44kb. Also removed the unused `forwardRef` import from the Planet component, although that is not expected to have any effect on the file size. 