### PR TITLE
Use gender-neutral pronoun for user on homepage

### DIFF
--- a/styleguide/components/landing-sections/UseCases.jsx
+++ b/styleguide/components/landing-sections/UseCases.jsx
@@ -52,7 +52,7 @@ const UseCases = () => (
           <Text>
             When you are building an app you have to think about those moments
             when there is no content. When the user lands in your app for the
-            first time, and there is nothing there. Or when he achieves
+            first time, and there is nothing there. Or when they achieve
             something, and it's a moment of success.
           </Text>
           <Text>


### PR DESCRIPTION
The homepage of this project is currently using "he" to refer to a generic user achieving something successfully. Since there's no character or other references, it makes sense to use more inclusive gender-neutral language here. ("They achieve")