### PR TITLE
add fix webpack adding window object to output of package

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,8 @@ module.exports = {
     filename: 'index.js',
     library: ['react-kawaii'],
     libraryTarget: 'umd',
-    publicPath: '/lib/'
+    publicPath: '/lib/',
+    globalObject: `typeof self !== 'undefined' ? self : this`,
   },
   module: {
     rules: [


### PR DESCRIPTION
@miukimiu this is the correct fix for the previous problem. I did a proper test this time by linking the project with my other nextjs project and it works fine now.

The issue was with webpack and had been reported a few times before, one of the solutions is seen here: https://github.com/webpack/webpack/issues/6525#issuecomment-417580843