### PR TITLE
change pathline from path file to import

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -23,6 +23,10 @@ module.exports = {
     }
   ],
   skipComponentsWithoutExample: true,
+  getComponentPathLine: pathname => {
+    const { name } = path.parse(pathname)
+    return `import { ${name} } from 'react-kawaii'`
+  },
   template: {
     head: {
       meta: [


### PR DESCRIPTION
Hi, first of all thanks for this lib, it's really awesome ❤️.

I have noticed that in the styleguide, the text below the components title are literally the path to the source code. So I just changed it to show an example of import as in [Get Started](https://react-kawaii.now.sh/#/Getting%20Started)