### PR TITLE
`[id]` attributes on the page are not unique

### DIFF
--- a/native/components/common/face/Face.js
+++ b/native/components/common/face/Face.js
@@ -61,8 +61,8 @@ const Face = ({ mood, uniqueId, ...rest }) => (
       fill="#000000"
       opacity="0.2"
     >
-      <Circle id="Oval" cx="3" cy="3" r="3" />
-      <Circle id="Oval" cx="63" cy="3" r="3" />
+      <Circle cx="3" cy="3" r="3" />
+      <Circle cx="63" cy="3" r="3" />
     </G>
     <G
       id="kawaii-face__eyes"
@@ -74,8 +74,8 @@ const Face = ({ mood, uniqueId, ...rest }) => (
           id="kawaii-face__eyes__arc"
           transform="translate(1.000000, 0.000000)"
         >
-          <Path d={paths.bliss1} id="Fill-5" />
-          <Path d={paths.bliss2} id="Fill-5" />
+          <Path d={paths.bliss1} />
+          <Path d={paths.bliss2} />
         </G>
       )}
       {(mood === 'happy' ||
@@ -86,8 +86,8 @@ const Face = ({ mood, uniqueId, ...rest }) => (
           id="kawaii-face__eyes__circle"
           transform="translate(1.000000, 2.000000)"
         >
-          <Circle id="Oval-3" cx="4.5" cy="4.5" r="4.5" />
-          <Circle id="Oval-3" cx="56.5" cy="4.5" r="4.5" />
+          <Circle cx="4.5" cy="4.5" r="4.5" />
+          <Circle cx="56.5" cy="4.5" r="4.5" />
         </G>
       )}
       {mood === 'lovestruck' && (
@@ -96,8 +96,8 @@ const Face = ({ mood, uniqueId, ...rest }) => (
           transform="translate(0.000000, 2.000000)"
           fillRule="nonzero"
         >
-          <Path d={paths.lovestruck1} id="Shape" />
-          <Path d={paths.lovestruck2} id="Shape" />
+          <Path d={paths.lovestruck1} />
+          <Path d={paths.lovestruck2} />
         </G>
       )}
       {mood === 'ko' && (
@@ -106,8 +106,8 @@ const Face = ({ mood, uniqueId, ...rest }) => (
           transform="translate(1.500000, 1.000000)"
           fillRule="nonzero"
         >
-          <Path d={paths.ko1} id="Cross" />
-          <Path d={paths.ko2} id="Cross" />
+          <Path d={paths.ko1} />
+          <Path d={paths.ko2} />
         </G>
       )}
     </G>

--- a/src/components/cat/Cat.jsx
+++ b/src/components/cat/Cat.jsx
@@ -46,8 +46,8 @@ const Cat = ({ size, color, mood, className }) => (
             fill={color}
             fillRule="nonzero"
           >
-            <path d="M55.949.205s27.948 51.641 2 53.898" id="arm-r" />
-            <path d="M13.641.205s-27.949 51.641-2 53.898" id="arm-l" />
+            <path d="M55.949.205s27.948 51.641 2 53.898" />
+            <path d="M13.641.205s-27.949 51.641-2 53.898" />
           </g>
           <g
             id="kawaii-cat_arms-shadow"
@@ -56,8 +56,8 @@ const Cat = ({ size, color, mood, className }) => (
             fillRule="nonzero"
             opacity="0.25"
           >
-            <path d="M55.949.205s27.948 51.641 2 53.898" id="arm-r" />
-            <path d="M13.641.205s-27.949 51.641-2 53.898" id="arm-l" />
+            <path d="M55.949.205s27.948 51.641 2 53.898" />
+            <path d="M13.641.205s-27.949 51.641-2 53.898" />
           </g>
           <path
             d={paths.body}

--- a/src/components/common/face/Face.jsx
+++ b/src/components/common/face/Face.jsx
@@ -59,8 +59,8 @@ const Face = ({ mood, uniqueId, ...rest }) => (
       fill="#000000"
       opacity="0.2"
     >
-      <circle id="Oval" cx="3" cy="3" r="3" />
-      <circle id="Oval" cx="63" cy="3" r="3" />
+      <circle cx="3" cy="3" r="3" />
+      <circle cx="63" cy="3" r="3" />
     </g>
     <g
       id="kawaii-face__eyes"
@@ -72,17 +72,20 @@ const Face = ({ mood, uniqueId, ...rest }) => (
           id="kawaii-face__eyes__arc"
           transform="translate(1.000000, 0.000000)"
         >
-          <path d={paths.bliss1} id="Fill-5" />
-          <path d={paths.bliss2} id="Fill-5" />
+          <path d={paths.bliss1} />
+          <path d={paths.bliss2} />
         </g>
       )}
-      {(mood === 'happy' || mood === 'sad' || mood === 'shocked' || mood === 'excited') && (
+      {(mood === 'happy' ||
+        mood === 'sad' ||
+        mood === 'shocked' ||
+        mood === 'excited') && (
         <g
           id="kawaii-face__eyes__circle"
           transform="translate(1.000000, 2.000000)"
         >
-          <circle id="Oval-3" cx="4.5" cy="4.5" r="4.5" />
-          <circle id="Oval-3" cx="56.5" cy="4.5" r="4.5" />
+          <circle cx="4.5" cy="4.5" r="4.5" />
+          <circle cx="56.5" cy="4.5" r="4.5" />
         </g>
       )}
       {mood === 'lovestruck' && (
@@ -110,7 +113,15 @@ const Face = ({ mood, uniqueId, ...rest }) => (
 );
 
 Face.propTypes = {
-  mood: PropTypes.oneOf(['sad', 'shocked', 'happy', 'blissful', 'lovestruck', 'excited', 'ko'])
+  mood: PropTypes.oneOf([
+    'sad',
+    'shocked',
+    'happy',
+    'blissful',
+    'lovestruck',
+    'excited',
+    'ko'
+  ])
 };
 
 Face.defaultProps = {


### PR DESCRIPTION
Accessibility fixes for assistive technologies and to improve the lighthouse score. 😄 

`[id]` attributes on the page are not unique. 

Each value of an id attribute must be unique to prevent other instances from being overlooked by assistive technologies.

There are still some more left to cover. Reference [rule](https://web.dev/duplicate-id/?utm_source=lighthouse&utm_medium=devtools) here.

<img width="726" alt="Screen Shot 2020-04-12 at 12 01 49 PM" src="https://user-images.githubusercontent.com/3586765/79073585-71e55080-7cb5-11ea-9af6-49e216e1c1ac.png">