### PR TITLE
fix: Export KawaiiFaceProps and KawaiiMood

### DIFF
--- a/.changeset/two-olives-report.md
+++ b/.changeset/two-olives-report.md
@@ -1,0 +1,5 @@
+---
+'react-kawaii': patch
+---
+
+Export KawaiiFaceProps and KawaiiMood types

--- a/packages/react-kawaii/src/index.ts
+++ b/packages/react-kawaii/src/index.ts
@@ -17,4 +17,4 @@ export { SpeechBubble } from './components/SpeechBubble';
 
 export { DEFAULT_PROPS, MOODS, PROPS_DATA } from './constants';
 
-export type { KawaiiProps } from './types';
+export type { KawaiiFaceProps, KawaiiMood, KawaiiProps } from './types';


### PR DESCRIPTION
Based on the [v1.0.0 changelog](https://github.com/elizabetdev/react-kawaii/blob/main/packages/react-kawaii/CHANGELOG.md#100), it seems like these types should be exported.